### PR TITLE
Fix backend url

### DIFF
--- a/web/.env.development
+++ b/web/.env.development
@@ -1,1 +1,0 @@
-VITE_API_URL=https://gorss-api.spyrosmoux.com/api/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.*

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4367,21 +4367,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/web/src/api/axios-instance.ts
+++ b/web/src/api/axios-instance.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosApp = axios.create({
-  baseURL: "https://gorss-api.spyrosmoux.com/api",
+  baseURL: import.meta.env.VITE_API_URL,
 });
 
 export default axiosApp;


### PR DESCRIPTION
## Summary

This PR removes the hardcoded API base URL from the frontend and introduces environment-based configuration using Vite’s `import.meta.env` mechanism.

---

## Changes Made

- Removed hardcoded `baseURL` from `axios-instance`
- Introduced environment-specific configuration via:
  - `.env.development`
  - `.env.production`
- Added `.env.*` to `.gitignore`
- Updated axios to use:

```js
import.meta.env.VITE_API_URL